### PR TITLE
feature: automated onboarding + confirmation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2904,7 +2904,13 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 name = "macros"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "pkcs8",
  "quote",
+ "rand 0.8.5",
+ "rsa",
+ "sha1",
  "syn",
 ]
 
@@ -5701,6 +5707,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-smithy-runtime-api",
+ "base64 0.22.1",
  "bigdecimal",
  "bytes",
  "cached",
@@ -5723,6 +5730,7 @@ dependencies = [
  "governor",
  "grass_compiler",
  "handlebars",
+ "hex",
  "hickory-resolver",
  "html5gum",
  "http 1.3.1",
@@ -5752,9 +5760,11 @@ dependencies = [
  "rocket",
  "rocket_ws",
  "rpassword",
+ "rsa",
  "semver",
  "serde",
  "serde_json",
+ "sha1",
  "subtle",
  "svg-hush",
  "syslog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,10 @@ libsqlite3-sys = { version = "0.35.0", features = ["bundled"], optional = true }
 rand = "0.9.2"
 ring = "0.17.14"
 subtle = "2.6.1"
+rsa = "0.9"
+sha1 = "0.10"
+hex = "0.4"
+base64 = "0.22"
 
 # UUID generation
 uuid = { version = "1.18.0", features = ["v4"] }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,6 +11,12 @@ proc-macro = true
 [dependencies]
 quote = "1.0.40"
 syn = "2.0.105"
+rsa = "0.9"
+rand = "0.8"
+sha1 = "0.10"
+base64 = "0.22"
+hex = "0.4"
+pkcs8 = "0.10"
 
 [lints]
 workspace = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -685,7 +685,9 @@ make_config! {
         /// Enforce Single Org with Reset Password Policy |> Enforce that the Single Org policy is enabled before setting the Reset Password policy
         /// Bitwarden enforces this by default. In Vaultwarden we encouraged to use multiple organizations because groups were not available.
         /// Setting this to true will enforce the Single Org Policy to be enabled before you can enable the Reset Password policy.
-        enforce_single_org_with_reset_pw_policy: bool, false, def, false;
+        enforce_single_org_with_reset_pw_policy: bool, false, def, false;    
+        /// Invited Email |> Email address to verify invitations against
+        invited_email: String, true, option;
     },
 
     /// OpenID Connect SSO settings


### PR DESCRIPTION
## This PR introduces a flow for creating organizations via a temporary bootstrap admin account:

### Temp Account Creation
A short-lived “admin” account is spun up solely to bootstrap a new organization.

### Authenticate Temp Account
The temp account authenticates via Client API to obtain an access_token.

### Organization Creation
Using the token, the temp account creates the organization (/api/organizations).

A raw 32-byte organization key (org key) is generated at this step.

### Invite Real Owner
Temp account sends an invite (/api/organizations/:id/invite) to the intended real owner’s email.

### Real Owner Registers
Owner accepts the invite, sets a master password, and generates their RSA keypair (public/private).

### Automated Confirmation + akey Injection
If invited_email matches the temp account, the invite is auto-confirmed.

The raw org key is encrypted with the owner’s public key.

The encrypted blob is stored as their akey.

### Temp Account Leaves
Once ownership is handed over, the temp account is removed from the org (DELETE /api/organizations/:id).